### PR TITLE
Describe assistive tech as sensitive, not benign.

### DIFF
--- a/index.bs
+++ b/index.bs
@@ -289,7 +289,7 @@ For example:
 * Financial data.
 * Contacts.
 * Calendar entries.
-* Whether the user is using assistive technology.
+* [Whether the user is using assistive technology.](https://w3ctag.github.io/design-principles/#do-not-expose-use-of-assistive-tech)
 * ...
 
 A particular piece of information may have different sensitivity for different

--- a/index.bs
+++ b/index.bs
@@ -259,9 +259,9 @@ user.
 The attributes can be exposed as information about the user's device that is
 otherwise benign (as opposed to [[#hl-sensitive-information]]). For example:
 
-* What hardware is connected to the user's device? A game controller? An
-    assistive device?
-* What system preferences has the user set? Dark mode, etc...
+* What are the user's language and time zone?
+* What size is the user's window?
+* What system preferences has the user set? Dark mode, serif font, etc...
 * ...
 
 See [[fingerprinting-guidance]] for how to mitigate this threat.
@@ -289,6 +289,7 @@ For example:
 * Financial data.
 * Contacts.
 * Calendar entries.
+* Whether the user is using assistive technology.
 * ...
 
 A particular piece of information may have different sensitivity for different


### PR DESCRIPTION
And avoid describing the user's choice of connected hardware as benign.

As, I believe, @joshueoconnor pointed out in https://lists.w3.org/Archives/Public/public-privacy/2020JanMar/0012.html, whether a user uses assistive technology is sensitive, not benign. This drove the design of [AOM's new input events](https://github.com/WICG/aom/blob/gh-pages/explainer.md#new-inputevent-types) in non-obvious ways, so it deserves to be called out here.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/privacy-threat-model/pull/22.html" title="Last updated on Aug 6, 2020, 6:24 PM UTC (5770b76)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3cping/privacy-threat-model/22/ded6a51...jyasskin:5770b76.html" title="Last updated on Aug 6, 2020, 6:24 PM UTC (5770b76)">Diff</a>